### PR TITLE
Fix: Prevent crash when Google account is not selected

The application was crashing with an `IllegalArgumentException` when making Google API calls because the `GoogleAccountCredential` was being used without a selected account.

This change introduces a check in the `GoogleApiService` to ensure an account name is present before creating the API clients. If no account is selected, it throws an exception.

This exception is now handled in the `AuthViewModel`, preventing the crash and allowing the UI to display a sign-in error to the user.

### DIFF
--- a/.gradle/buildOutputCleanup/cache.properties
+++ b/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,2 @@
-#Thu Sep 11 03:37:29 UTC 2025
+#Thu Sep 11 07:51:51 UTC 2025
 gradle.version=8.13

--- a/app/src/main/java/com/hereliesaz/lexorcist/service/GoogleApiService.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/service/GoogleApiService.kt
@@ -31,12 +31,21 @@ import kotlinx.coroutines.withContext
 // Removed @Inject from constructor
 class GoogleApiService constructor(credential: GoogleAccountCredential, applicationName: String) {
 
-    private val drive: Drive = Drive.Builder(NetHttpTransport(), GsonFactory.getDefaultInstance(), credential)
-        .setApplicationName(applicationName)
-        .build()
-    private val sheets: Sheets = Sheets.Builder(NetHttpTransport(), GsonFactory.getDefaultInstance(), credential)
-        .setApplicationName(applicationName)
-        .build()
+    private val drive: Drive
+    private val sheets: Sheets
+
+    init {
+        if (credential.selectedAccountName == null) {
+            throw IllegalArgumentException("Account name must not be empty. Please select an account.")
+        }
+        drive = Drive.Builder(NetHttpTransport(), GsonFactory.getDefaultInstance(), credential)
+            .setApplicationName(applicationName)
+            .build()
+        sheets = Sheets.Builder(NetHttpTransport(), GsonFactory.getDefaultInstance(), credential)
+            .setApplicationName(applicationName)
+            .build()
+    }
+
 
     // Secondary constructor if needed, but Hilt will use the @Inject annotated one.
     // constructor(drive: Drive, sheets: Sheets) : this( TODO: figure out how to get credential and app name from drive/sheets or remove this ctor

--- a/app/src/main/java/com/hereliesaz/lexorcist/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/viewmodel/AuthViewModel.kt
@@ -135,9 +135,18 @@ class AuthViewModel
             val scopes = listOf(DriveScopes.DRIVE_FILE, SheetsScopes.SPREADSHEETS)
             val accountCredential = GoogleAccountCredential.usingOAuth2(application, scopes)
             accountCredential.selectedAccountName = userId // Use userId (email)
-            
+
             credentialHolder.credential = accountCredential
-            credentialHolder.googleApiService = com.hereliesaz.lexorcist.service.GoogleApiService(accountCredential, application.packageName)
+            try {
+                credentialHolder.googleApiService =
+                    com.hereliesaz.lexorcist.service.GoogleApiService(
+                        accountCredential,
+                        application.packageName,
+                    )
+            } catch (e: IllegalArgumentException) {
+                Log.e(TAG, "Error initializing GoogleApiService", e)
+                onSignInError(e)
+            }
         }
 
         fun onSignInError(error: Exception) {


### PR DESCRIPTION
## Summary by Sourcery

Validate Google account selection before initializing API clients and handle missing account scenarios in the ViewModel to prevent crashes and report sign-in errors.

Bug Fixes:
- Add check for selectedAccountName in GoogleApiService constructor to avoid IllegalArgumentException when no account is chosen
- Catch account initialization errors in AuthViewModel to prevent crashes and invoke the sign-in error handler