### PR TITLE
Production hardening: build fixes, crash/leak fixes, Drive sync, security

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,18 +5,25 @@ on:
     tags:
       - '*'
 
+# Least-privilege token: the release step needs to write a GitHub Release.
+permissions:
+  contents: write
+
 jobs:
   Gradle:
     runs-on: ubuntu-latest
     steps:
     - name: checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: setup jdk
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
+        distribution: temurin
+        java-version: '17'
     - name: Make Gradle executable
       run: chmod +x ./gradlew
+    # Release signing reads MY_KEYSTORE_FILE / MY_KEYSTORE_PASSWORD / MY_KEY_PASSWORD.
+    # Configure these as repository secrets (and decode the keystore to a file) for a signed build.
     - name: Build Release APK
       run: ./gradlew assembleRelease
     - name: Releasing using Hub

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,6 +120,25 @@ dependencies {
         implementation(libs.kotlin.stdlib.jdk7) {
             because("Align kotlin versions")
         }
+
+        // --- Security: force-upgrade vulnerable transitive dependencies to patched ---
+        // releases (Dependabot alerts). These are constraints, so they are no-ops for any
+        // coordinate not actually present in the resolved graph. Dependabot remains the
+        // source of truth for newer CVEs published after these pins.
+        implementation("org.bouncycastle:bcprov-jdk18on:1.78.1") { because("CVE: timing channel / resource consumption") }
+        implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1") { because("CVE: BouncyCastle (MSAL/Graph, iText)") }
+        implementation("org.bouncycastle:bcutil-jdk18on:1.78.1") { because("CVE: BouncyCastle (MSAL/Graph)") }
+        implementation("org.bouncycastle:bcpg-jdk18on:1.78.1") { because("CVE: BouncyCastle uncontrolled resource consumption") }
+        implementation("org.bitbucket.b_c:jose4j:0.9.6") { because("CVE: jose4j DoS via compressed JWE (MSAL)") }
+        implementation("org.jdom:jdom2:2.0.6.1") { because("CVE-2021-33813: JDOM XXE (Apache POI)") }
+        implementation("org.apache.commons:commons-lang3:3.18.0") { because("CVE: commons-lang3 uncontrolled recursion (POI)") }
+        implementation("org.apache.commons:commons-compress:1.27.1") { because("CVE: commons-compress Pack200 OOM (POI)") }
+        implementation("com.fasterxml.jackson.core:jackson-core:2.18.2") { because("CVE: jackson-core async parser DoS") }
+        implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2") { because("CVE: align jackson-databind with patched core") }
+        implementation("io.netty:netty-codec-http2:4.1.118.Final") { because("CVE: Netty HTTP/2 DoS family") }
+        implementation("io.netty:netty-codec-http:4.1.118.Final") { because("CVE: Netty HTTP request smuggling / decompression") }
+        implementation("io.netty:netty-codec:4.1.118.Final") { because("CVE: Netty codec resource exhaustion / zip bomb") }
+        implementation("io.netty:netty-handler:4.1.118.Final") { because("CVE: Netty SslHandler / SNI allocation") }
     }
 
     implementation(libs.androidx.core.ktx)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,3 +32,59 @@
 
 # For MediaPipe
 -keep class com.google.mediapipe.** { *; }
+
+# Keep Hilt DI subpackages (qualifiers, generated modules), not just the top level.
+-keep class com.hereliesaz.lexorcist.di.** { *; }
+
+# Mozilla Rhino — the scripting engine reflects over its own classes at runtime.
+-keep class org.mozilla.javascript.** { *; }
+-dontwarn org.mozilla.javascript.**
+
+# Apache POI (XLSX read/write) — heavy reflection + optional deps.
+-keep class org.apache.poi.** { *; }
+-keep class org.openxmlformats.** { *; }
+-keep class org.apache.xmlbeans.** { *; }
+-keep class schemaorg_apache_xmlbeans.** { *; }
+-dontwarn org.apache.poi.**
+-dontwarn org.openxmlformats.**
+-dontwarn org.apache.xmlbeans.**
+
+# iText (PDF generation).
+-keep class com.itextpdf.** { *; }
+-dontwarn com.itextpdf.**
+
+# Google API client (models are accessed reflectively by the JSON parser).
+-keep class com.google.api.client.** { *; }
+-keep class com.google.api.** { *; }
+-dontwarn com.google.api.client.**
+
+# gRPC (used transitively by Google/Firebase clients).
+-keep class io.grpc.** { *; }
+-dontwarn io.grpc.**
+
+# Microsoft MSAL / identity (OneDrive auth — disabled but still linked).
+-keep class com.microsoft.identity.** { *; }
+-dontwarn com.microsoft.identity.**
+-dontwarn com.microsoft.graph.**
+
+# Dropbox SDK.
+-keep class com.dropbox.** { *; }
+-dontwarn com.dropbox.**
+
+# Jakarta Mail (IMAP).
+-keep class jakarta.mail.** { *; }
+-keep class com.sun.mail.** { *; }
+-dontwarn jakarta.mail.**
+-dontwarn com.sun.mail.**
+
+# Vosk speech-to-text (JNI bindings).
+-keep class org.vosk.** { *; }
+-dontwarn org.vosk.**
+
+# TensorFlow Lite / AI Edge runtime.
+-keep class org.tensorflow.** { *; }
+-keep class com.google.ai.edge.** { *; }
+-dontwarn org.tensorflow.**
+
+# Keep annotated model fields used by reflective (de)serialization.
+-keepattributes Signature, *Annotation*, InnerClasses, EnclosingMethod

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,14 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <!-- Legacy storage read, only needed up to Android 12 (API 32). -->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <!-- Android 13+ (API 33) granular media permissions. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.READ_CALL_LOG" />

--- a/app/src/main/java/com/hereliesaz/lexorcist/data/CaseRepositoryImpl.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/data/CaseRepositoryImpl.kt
@@ -105,13 +105,15 @@ class CaseRepositoryImpl @Inject constructor(
             is Result.Loading -> {
                 Log.d(tag, "Refreshing allegations for $spreadsheetId: Loading...")
             }
-            is Result.Success -> if (repositoryScope.isActive) _allegations.value = result.data
+            // Only apply the result if this case is still the selected one, so a stale load
+            // from a previously-selected case can't overwrite the current case's allegations.
+            is Result.Success -> if (_selectedCase.value?.spreadsheetId == spreadsheetId) _allegations.value = result.data
             is Result.Error -> {
-                if (repositoryScope.isActive) _allegations.value = emptyList()
+                if (_selectedCase.value?.spreadsheetId == spreadsheetId) _allegations.value = emptyList()
                 errorReporter.reportError(result.exception)
             }
             is Result.UserRecoverableError -> {
-                if (repositoryScope.isActive) _allegations.value = emptyList()
+                if (_selectedCase.value?.spreadsheetId == spreadsheetId) _allegations.value = emptyList()
                 errorReporter.reportError(result.exception)
             }
         }

--- a/app/src/main/java/com/hereliesaz/lexorcist/data/EvidenceRepositoryImpl.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/data/EvidenceRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.lexorcist.data
 
 import android.app.Application
 import android.net.Uri
+import android.util.Log
 import com.hereliesaz.lexorcist.utils.EvidenceCacheManager
 import com.hereliesaz.lexorcist.utils.Result
 import kotlinx.coroutines.flow.Flow
@@ -20,6 +21,10 @@ constructor(
     private val evidenceCacheManager: EvidenceCacheManager,
     private val application: Application,
 ) : EvidenceRepository {
+    private companion object {
+        private const val TAG = "EvidenceRepositoryImpl"
+    }
+
     private val evidenceByCaseMap =
         mutableMapOf<String, MutableStateFlow<List<Evidence>>>()
 
@@ -49,8 +54,10 @@ constructor(
                 evidenceCacheManager.saveEvidence(caseId, result.data)
                 evidenceByCaseMap[spreadsheetId]?.value = result.data
             }
-            is Result.Error -> { /* Handle error */ }
-            is Result.UserRecoverableError -> { /* Handle error */ }
+            is Result.Error ->
+                Log.e(TAG, "Failed to refresh evidence for spreadsheet $spreadsheetId", result.exception)
+            is Result.UserRecoverableError ->
+                Log.w(TAG, "User-recoverable error refreshing evidence for spreadsheet $spreadsheetId", result.exception)
         }
     }
 
@@ -90,16 +97,20 @@ constructor(
     }
 
     override suspend fun updateEvidence(evidence: Evidence) {
-        when (localFileStorageService.updateEvidence(evidence.spreadsheetId, evidence)) {
+        when (val result = localFileStorageService.updateEvidence(evidence.spreadsheetId, evidence)) {
             is Result.Success<Unit> -> refreshEvidence(evidence.spreadsheetId, evidence.caseId)
-            else -> { /* Handle error */ }
+            is Result.Error -> Log.e(TAG, "Failed to update evidence ${evidence.id}", result.exception)
+            is Result.UserRecoverableError -> Log.w(TAG, "User-recoverable error updating evidence ${evidence.id}", result.exception)
+            is Result.Loading -> { /* No terminal state to handle */ }
         }
     }
 
     override suspend fun deleteEvidence(evidence: Evidence) {
-        when (localFileStorageService.deleteEvidence(evidence.spreadsheetId, evidence)) {
+        when (val result = localFileStorageService.deleteEvidence(evidence.spreadsheetId, evidence)) {
             is Result.Success<Unit> -> refreshEvidence(evidence.spreadsheetId, evidence.caseId)
-            else -> { /* Handle error */ }
+            is Result.Error -> Log.e(TAG, "Failed to delete evidence ${evidence.id}", result.exception)
+            is Result.UserRecoverableError -> Log.w(TAG, "User-recoverable error deleting evidence ${evidence.id}", result.exception)
+            is Result.Loading -> { /* No terminal state to handle */ }
         }
     }
 

--- a/app/src/main/java/com/hereliesaz/lexorcist/data/LocalFileStorageService.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/data/LocalFileStorageService.kt
@@ -58,12 +58,10 @@ class LocalFileStorageService @Inject constructor(
     // The directory where application data is stored. Can be customized by the user.
     private val storageDir: File by lazy {
         val customLocation = settingsManager.getStorageLocation()
-        val dir = if (customLocation != null) {
-            File(customLocation.toUri().path!!)
-        } else {
-            // Fallback to internal storage if no custom location is set.
-            context.getExternalFilesDir(null) ?: context.filesDir
-        }
+        // Fall back to internal storage if no (valid) custom location is set.
+        val dir = customLocation?.toUri()?.path?.let { File(it) }
+            ?: context.getExternalFilesDir(null)
+            ?: context.filesDir
         if (!dir.exists()) dir.mkdirs()
         dir
     }
@@ -347,8 +345,14 @@ class LocalFileStorageService @Inject constructor(
 
     suspend fun moveFilesToNewLocation(oldLocation: String, newLocation: String) {
         withContext(Dispatchers.IO) {
-            val oldDir = File(oldLocation.toUri().path!!)
-            val newDir = File(newLocation.toUri().path!!)
+            val oldPath = oldLocation.toUri().path
+            val newPath = newLocation.toUri().path
+            if (oldPath == null || newPath == null) {
+                Log.e("LocalFileStorageService", "Invalid storage path for move: old=$oldLocation, new=$newLocation")
+                return@withContext
+            }
+            val oldDir = File(oldPath)
+            val newDir = File(newPath)
             if (oldDir.exists() && oldDir.isDirectory) {
                 oldDir.copyRecursively(newDir, overwrite = true)
                 oldDir.deleteRecursively()
@@ -803,8 +807,8 @@ class LocalFileStorageService @Inject constructor(
                     } else {
                         Log.e("LocalFileStorageService", "Could not find case details for $caseSpreadsheetId to enqueue video processing.")
                     }
-                } else if (casesResult is Result.Error) {
-                     Log.e("LocalFileStorageService", "Failed to retrieve case list to enqueue video processing: ${casesResult.exception.message}")
+                } else if (caseResult is Result.Error) {
+                     Log.e("LocalFileStorageService", "Failed to retrieve case list to enqueue video processing: ${caseResult.exception.message}")
                 }
             }
 

--- a/app/src/main/java/com/hereliesaz/lexorcist/data/SyncManager.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/data/SyncManager.kt
@@ -19,11 +19,9 @@ class SyncManager @Inject constructor(
 ) {
     private val storageDir: File by lazy {
         val customLocation = settingsManager.getStorageLocation()
-        val dir = if (customLocation != null) {
-            File(customLocation.toUri().path!!)
-        } else {
-            context.getExternalFilesDir(null) ?: context.filesDir
-        }
+        val dir = customLocation?.toUri()?.path?.let { File(it) }
+            ?: context.getExternalFilesDir(null)
+            ?: context.filesDir
         if (!dir.exists()) dir.mkdirs()
         dir
     }

--- a/app/src/main/java/com/hereliesaz/lexorcist/di/AppModule.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/di/AppModule.kt
@@ -180,7 +180,7 @@ class AppModule {
         @ApplicationContext context: Context,
         fusedLocationProviderClient: com.google.android.gms.location.FusedLocationProviderClient
     ): EvidenceImporter {
-        return EvidenceImporter(context.contentResolver, fusedLocationProviderClient)
+        return EvidenceImporter(context, context.contentResolver, fusedLocationProviderClient)
     }
 
     /**

--- a/app/src/main/java/com/hereliesaz/lexorcist/di/GoogleDriveModule.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/di/GoogleDriveModule.kt
@@ -1,16 +1,10 @@
 package com.hereliesaz.lexorcist.di
 
-import android.content.Context
-// Removed: import com.hereliesaz.lexorcist.auth.CredentialHolder // No longer needed here
-import com.hereliesaz.lexorcist.data.CloudFile
 import com.hereliesaz.lexorcist.data.CloudStorageProvider
-import com.hereliesaz.lexorcist.data.GoogleDriveProvider
-// import com.hereliesaz.lexorcist.service.GoogleApiService // Removed for diagnostics
-import com.hereliesaz.lexorcist.utils.Result
+import com.hereliesaz.lexorcist.data.GoogleDriveCloudStorageProvider
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Named
 import javax.inject.Singleton
@@ -19,19 +13,15 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object GoogleDriveModule {
 
-    // Removed the provideGoogleApiService method as GoogleApiService is now directly injectable by Hilt
-    // @Provides
-    // @Singleton
-    // fun provideGoogleApiService(credentialHolder: CredentialHolder): GoogleApiService? {
-    //     return credentialHolder.googleApiService
-    // }
-
+    /**
+     * Binds the real Google Drive implementation ([GoogleDriveCloudStorageProvider], which delegates
+     * to [com.hereliesaz.lexorcist.service.GoogleApiService]) as the "googleDrive" cloud provider.
+     * Hilt constructs the provider via its @Inject constructor.
+     */
     @Provides
     @Singleton
     @Named("googleDrive")
     fun provideGoogleDriveProvider(
-        @ApplicationContext context: Context
-    ): CloudStorageProvider {
-        return GoogleDriveProvider(context) // Now calling the modified constructor
-    }
+        provider: GoogleDriveCloudStorageProvider
+    ): CloudStorageProvider = provider
 }

--- a/app/src/main/java/com/hereliesaz/lexorcist/service/AppLifecycleObserver.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/service/AppLifecycleObserver.kt
@@ -1,9 +1,10 @@
 package com.hereliesaz.lexorcist.service
 
+import android.util.Log
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.hereliesaz.lexorcist.data.CaseRepository
 import com.hereliesaz.lexorcist.di.qualifiers.ApplicationScope // Import the qualifier
+import com.hereliesaz.lexorcist.utils.Result
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -17,11 +18,26 @@ class AppLifecycleObserver @Inject constructor(
     @ApplicationScope private val applicationScope: CoroutineScope // Added qualifier
 ) : DefaultLifecycleObserver {
 
+    private companion object {
+        private const val TAG = "AppLifecycleObserver"
+    }
+
     override fun onStop(owner: LifecycleOwner) {
         super.onStop(owner)
         if (settingsManager.getCloudSyncEnabled()) {
             applicationScope.launch(Dispatchers.IO) {
-                storageService.synchronize()
+                try {
+                    when (val result = storageService.synchronize()) {
+                        is Result.Error ->
+                            Log.e(TAG, "Cloud sync failed", result.exception)
+                        is Result.UserRecoverableError ->
+                            Log.w(TAG, "Cloud sync needs user action (e.g. re-auth)", result.exception)
+                        else ->
+                            Log.i(TAG, "Cloud sync completed")
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Cloud sync threw an unexpected exception", e)
+                }
             }
         }
     }

--- a/app/src/main/java/com/hereliesaz/lexorcist/service/GlobalLoadingState.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/service/GlobalLoadingState.kt
@@ -3,27 +3,28 @@ package com.hereliesaz.lexorcist.service
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class GlobalLoadingState @Inject constructor() {
 
-    private val loadingCount = AtomicInteger(0)
+    private var loadingCount = 0
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
+    // Synchronized so the counter update and the StateFlow update are atomic together,
+    // preventing interleaved push/pop from leaving isLoading inconsistent with the count.
+    @Synchronized
     fun pushLoading() {
-        if (loadingCount.incrementAndGet() > 0) {
-            _isLoading.value = true
-        }
+        loadingCount++
+        _isLoading.value = loadingCount > 0
     }
 
+    @Synchronized
     fun popLoading() {
-        if (loadingCount.decrementAndGet() <= 0) {
-            _isLoading.value = false
-        }
+        if (loadingCount > 0) loadingCount--
+        _isLoading.value = loadingCount > 0
     }
 }

--- a/app/src/main/java/com/hereliesaz/lexorcist/service/GoogleApiService.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/service/GoogleApiService.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import com.google.api.client.googleapis.extensions.android.gms.auth.UserRecoverableAuthIOException
 import com.google.api.client.http.FileContent
+import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.drive.Drive
@@ -61,11 +62,22 @@ class GoogleApiService @Inject constructor(
     }
 
     /**
+     * Wraps a credential (or null) with connect/read timeouts so network calls don't hang
+     * indefinitely on a stalled connection.
+     */
+    private fun withTimeouts(initializer: HttpRequestInitializer?): HttpRequestInitializer =
+        HttpRequestInitializer { request ->
+            initializer?.initialize(request)
+            request.connectTimeout = 30_000 // 30s
+            request.readTimeout = 60_000 // 60s
+        }
+
+    /**
      * Helper to build an authenticated Drive service client.
      */
     private fun getDriveService(): Drive? {
         return credentialHolder.credential?.let { cred ->
-            Drive.Builder(httpTransport, gsonFactory, cred)
+            Drive.Builder(httpTransport, gsonFactory, withTimeouts(cred))
                 .setApplicationName(applicationName)
                 .build()
         }
@@ -108,7 +120,7 @@ class GoogleApiService @Inject constructor(
 
     private fun getScriptService(): com.google.api.services.script.Script? {
         return credentialHolder.credential?.let { cred ->
-            com.google.api.services.script.Script.Builder(httpTransport, gsonFactory, cred)
+            com.google.api.services.script.Script.Builder(httpTransport, gsonFactory, withTimeouts(cred))
                 .setApplicationName(applicationName)
                 .build()
         }
@@ -118,14 +130,14 @@ class GoogleApiService @Inject constructor(
      * Returns a Sheets service instance without credentials, for accessing public/read-only sheets.
      */
     private fun getPublicSheetsService(): Sheets {
-        return Sheets.Builder(httpTransport, gsonFactory, null)
+        return Sheets.Builder(httpTransport, gsonFactory, withTimeouts(null))
             .setApplicationName(applicationName)
             .build()
     }
 
     private fun getSheetsService(): Sheets? {
         return credentialHolder.credential?.let { cred ->
-            Sheets.Builder(httpTransport, gsonFactory, cred)
+            Sheets.Builder(httpTransport, gsonFactory, withTimeouts(cred))
                 .setApplicationName(applicationName)
                 .build()
         }

--- a/app/src/main/java/com/hereliesaz/lexorcist/service/OcrProcessingService.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/service/OcrProcessingService.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.lexorcist.service
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Log
@@ -17,7 +18,9 @@ import com.hereliesaz.lexorcist.model.ProcessingState
 import com.hereliesaz.lexorcist.utils.DataParser
 import com.hereliesaz.lexorcist.utils.ExifUtils
 import com.hereliesaz.lexorcist.utils.Result
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
@@ -55,10 +58,59 @@ constructor(
      * @param uri The URI of the image to process (content:// or file://).
      * @return The extracted text as a String.
      */
+    private fun openStream(context: Context, uri: Uri): InputStream {
+        return when (uri.scheme) {
+            "content" ->
+                context.contentResolver.openInputStream(uri)
+                    ?: throw java.io.FileNotFoundException("Failed to open InputStream for URI: $uri")
+            "file", null -> {
+                val path = uri.path ?: throw java.io.FileNotFoundException("URI path is null")
+                val file = File(path)
+                if (!file.exists()) throw java.io.FileNotFoundException("File not found at path: $path")
+                FileInputStream(file)
+            }
+            else -> throw IllegalArgumentException("Unsupported URI scheme: ${uri.scheme}")
+        }
+    }
+
+    /**
+     * Decodes a bitmap from the URI, downsampling so neither dimension exceeds [maxDimension].
+     * This caps memory use and prevents OutOfMemory errors on large document scans.
+     */
+    private fun decodeSampledBitmap(context: Context, uri: Uri, maxDimension: Int = 2048): Bitmap {
+        // First pass: read only the bounds.
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        openStream(context, uri).use { BitmapFactory.decodeStream(it, null, bounds) }
+
+        var sampleSize = 1
+        while (bounds.outHeight / sampleSize > maxDimension || bounds.outWidth / sampleSize > maxDimension) {
+            sampleSize *= 2
+        }
+
+        // Second pass: decode at the computed sample size.
+        val options = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+        return openStream(context, uri).use { BitmapFactory.decodeStream(it, null, options) }
+            ?: throw RuntimeException("Failed to decode bitmap from URI: $uri")
+    }
+
     private suspend fun recognizeTextFromUri(
         context: Context,
         uri: Uri,
     ): String {
+        val bitmap = withContext(Dispatchers.IO) { decodeSampledBitmap(context, uri) }
+        return try {
+            recognizeTextFromBitmap(bitmap)
+        } finally {
+            // We own this bitmap; recognizeTextFromBitmap has finished with it by now.
+            bitmap.recycle()
+        }
+    }
+
+    /**
+     * Runs MLKit OCR on an already-decoded [Bitmap]. The caller retains ownership of the
+     * bitmap and is responsible for recycling it after this function returns.
+     */
+    suspend fun recognizeTextFromBitmap(bitmap: Bitmap): String {
         // Initialize MLKit Text Recognizer with default options (Latin script).
         val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
         try {
@@ -66,56 +118,14 @@ constructor(
             return suspendCancellableCoroutine { continuation ->
                 // Ensure the recognizer is closed if the coroutine is cancelled.
                 continuation.invokeOnCancellation { recognizer.close() }
-                val image: InputImage
-                var inputStream: InputStream? = null
-                try {
-                    // Handle different URI schemes to get an InputStream.
-                    when (uri.scheme) {
-                        "content" -> {
-                            inputStream = context.contentResolver.openInputStream(uri)
-                        }
-                        "file", null -> {
-                            uri.path?.let {
-                                val file = File(it)
-                                if (file.exists()) {
-                                    inputStream = FileInputStream(file)
-                                } else {
-                                    throw java.io.FileNotFoundException("File not found at path: $it")
-                                }
-                            } ?: throw java.io.FileNotFoundException("URI path is null")
-                        }
-                        else -> {
-                            throw IllegalArgumentException("Unsupported URI scheme: ${uri.scheme}")
-                        }
-                    }
-
-                    if (inputStream == null) {
-                        throw java.io.FileNotFoundException("Failed to open InputStream for URI: $uri")
-                    }
-
-                    val bitmap = BitmapFactory.decodeStream(inputStream)
-
-                    if (bitmap == null) {
-                        continuation.resumeWithException(RuntimeException("Failed to decode bitmap from URI: $uri"))
-                        return@suspendCancellableCoroutine
-                    }
-                    // Create MLKit InputImage. Rotation is set to 0 as we assume correct orientation or don't handle it yet.
-                    image = InputImage.fromBitmap(bitmap, 0)
-                } catch (e: Exception) {
-                    Log.e("OcrProcessingService", "Error creating InputImage from URI: $uri", e)
-                    continuation.resumeWithException(e)
-                    return@suspendCancellableCoroutine
-                } finally {
-                    inputStream?.close()
-                }
-
-                // Process the image asynchronously.
+                // Rotation is set to 0 as we assume correct orientation or don't handle it yet.
+                val image = InputImage.fromBitmap(bitmap, 0)
                 recognizer
                     .process(image)
                     .addOnSuccessListener { visionText ->
                         continuation.resume(visionText.text)
                     }.addOnFailureListener { e ->
-                        Log.e("OcrProcessingService", "Text recognition failed for URI: $uri", e)
+                        Log.e("OcrProcessingService", "Text recognition failed", e)
                         continuation.resumeWithException(e)
                     }
             }

--- a/app/src/main/java/com/hereliesaz/lexorcist/service/PackagingService.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/service/PackagingService.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.lexorcist.service
 
 import android.content.Context
 import android.net.Uri
+import android.provider.DocumentsContract
 import com.hereliesaz.lexorcist.utils.DispatcherProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.withContext
@@ -16,16 +17,24 @@ class PackagingService @Inject constructor(
 ) {
     suspend fun createArchive(files: List<File>, destinationUri: Uri) {
         withContext(dispatcherProvider.io()) {
-            context.contentResolver.openOutputStream(destinationUri)?.use { outputStream ->
-                ZipOutputStream(outputStream).use { zos ->
-                    files.forEach { file ->
-                        zos.putNextEntry(ZipEntry(file.name))
-                        file.inputStream().use { fis ->
-                            fis.copyTo(zos)
+            try {
+                context.contentResolver.openOutputStream(destinationUri)?.use { outputStream ->
+                    ZipOutputStream(outputStream).use { zos ->
+                        files.forEach { file ->
+                            zos.putNextEntry(ZipEntry(file.name))
+                            file.inputStream().use { fis ->
+                                fis.copyTo(zos)
+                            }
+                            zos.closeEntry()
                         }
-                        zos.closeEntry()
                     }
                 }
+            } catch (e: Exception) {
+                // Remove the partially-written archive so the user isn't left with a corrupt file.
+                try {
+                    DocumentsContract.deleteDocument(context.contentResolver, destinationUri)
+                } catch (_: Exception) { /* best-effort cleanup */ }
+                throw e
             }
         }
     }

--- a/app/src/main/java/com/hereliesaz/lexorcist/service/ScriptRunner.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/service/ScriptRunner.kt
@@ -73,10 +73,10 @@ class ScriptRunner @Inject constructor(
      * @param evidence The [Evidence] object to be processed/analyzed.
      * @return A [Result] containing the [ScriptResult] (tags, notes, etc.) or an error.
      */
-    fun runScript(
+    suspend fun runScript(
         script: String,
         evidence: Evidence
-    ): Result<ScriptResult> {
+    ): Result<ScriptResult> = withContext(Dispatchers.Default) {
         val rhino = Context.enter()
         // IMPORTANT: optimizationLevel = -1 is required for Android compatibility.
         // Higher levels use dynamic bytecode generation which is not supported by Dalvik/ART.
@@ -127,12 +127,12 @@ class ScriptRunner @Inject constructor(
             // Execute the user's script.
             rhino.evaluateString(scope, script, "JavaScript<ScriptRunner>", 1, null)
 
-            return Result.Success(scriptResult)
+            return@withContext Result.Success(scriptResult)
 
         } catch (e: org.mozilla.javascript.RhinoException) {
-            return Result.Error(ScriptExecutionException("Error during JavaScript execution", e))
+            return@withContext Result.Error(ScriptExecutionException("Error during JavaScript execution", e))
         } catch (e: Exception) {
-            return Result.Error(ScriptExecutionException("An unexpected error occurred while running script or processing results", e))
+            return@withContext Result.Error(ScriptExecutionException("An unexpected error occurred while running script or processing results", e))
         } finally {
             Context.exit()
         }

--- a/app/src/main/java/com/hereliesaz/lexorcist/service/VideoProcessingService.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/service/VideoProcessingService.kt
@@ -3,7 +3,7 @@ package com.hereliesaz.lexorcist.service
 import android.content.Context
 import android.media.MediaMetadataRetriever
 import android.net.Uri
-import androidx.tracing.trace
+import android.util.Log
 import com.hereliesaz.lexorcist.utils.DispatcherProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.withContext
@@ -17,36 +17,39 @@ class VideoProcessingService @Inject constructor(
 
     companion object {
         private const val FRAME_EXTRACTION_INTERVAL_MS = 5000L
+        private const val TAG = "VideoProcessingService"
     }
 
     suspend fun processVideo(uri: Uri): String = withContext(dispatcherProvider.io()) {
-        trace("processVideo") {
-            val retriever = MediaMetadataRetriever()
+        val retriever = MediaMetadataRetriever()
+        val ocrText = StringBuilder()
+        try {
             retriever.setDataSource(context, uri)
 
             val durationString = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
             val duration = durationString?.toLongOrNull() ?: 0
 
-            val ocrText = StringBuilder()
             var currentTime = 0L
             while (currentTime < duration) {
                 val frame = retriever.getFrameAtTime(currentTime * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
                 if (frame != null) {
-                    // This is a placeholder as processBitmap doesn't exist.
-                    // To make this compile, we'll assume a suspend function processImageFrame exists and returns text.
-                    // This will likely need a proper implementation later.
-                    // For now, we just get an empty string.
-                    val text = ""
-                    if (text.isNotBlank()) {
-                        ocrText.append(text).append("\n")
+                    try {
+                        val text = ocrProcessingService.recognizeTextFromBitmap(frame)
+                        if (text.isNotBlank()) {
+                            ocrText.append(text).append("\n")
+                        }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "OCR failed for frame at ${currentTime}ms", e)
+                    } finally {
+                        frame.recycle()
                     }
                 }
                 currentTime += FRAME_EXTRACTION_INTERVAL_MS
             }
-
+        } finally {
             retriever.release()
-
-            "## OCR Text\n$ocrText"
         }
+
+        "## OCR Text\n$ocrText"
     }
 }

--- a/app/src/main/java/com/hereliesaz/lexorcist/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/ui/SettingsScreen.kt
@@ -238,7 +238,14 @@ fun SettingsScreen(
             )
             Spacer(modifier = Modifier.height(8.dp))
             val selectedCloudProvider by settingsViewModel.selectedCloudProvider.collectAsState()
-            val cloudProviders = listOf("GoogleDrive", "Dropbox", "OneDrive", "None")
+            // OneDrive/Dropbox sync is not implemented yet; only Google Drive is offered.
+            // Flip this to re-enable their selection and connection UI once implemented.
+            val showExperimentalCloudProviders = false
+            val cloudProviders = if (showExperimentalCloudProviders) {
+                listOf("GoogleDrive", "Dropbox", "OneDrive", "None")
+            } else {
+                listOf("GoogleDrive", "None")
+            }
             AzCycler(
                 options = cloudProviders,
                 selectedOption = selectedCloudProvider,
@@ -300,6 +307,7 @@ fun SettingsScreen(
             HorizontalDivider()
             Spacer(modifier = Modifier.height(16.dp))
 
+            if (showExperimentalCloudProviders) {
             // Dropbox
             Text(
                 text = stringResource(R.string.dropbox),
@@ -376,6 +384,7 @@ fun SettingsScreen(
                     )
                 }
             }
+            } // end if (showExperimentalCloudProviders)
 
             Spacer(modifier = Modifier.height(16.dp))
             HorizontalDivider()

--- a/app/src/main/java/com/hereliesaz/lexorcist/utils/EvidenceImporter.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/utils/EvidenceImporter.kt
@@ -1,10 +1,15 @@
 package com.hereliesaz.lexorcist.utils
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.content.ContentResolver
+import android.content.Context
+import android.content.pm.PackageManager
 import android.location.Location
 import android.provider.CallLog
 import android.provider.Telephony
+import android.util.Log
+import androidx.core.content.ContextCompat
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.hereliesaz.lexorcist.data.Evidence
 import java.util.Date
@@ -13,6 +18,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 class EvidenceImporter(
+    private val context: Context,
     private val contentResolver: ContentResolver,
     private val fusedLocationProviderClient: FusedLocationProviderClient
 ) {
@@ -151,7 +157,14 @@ class EvidenceImporter(
      * A full location history would require a different approach, such as Google Takeout.
      */
     @SuppressLint("MissingPermission")
-    suspend fun importLocationHistory(): Evidence? = suspendCoroutine { continuation ->
+    suspend fun importLocationHistory(): Evidence? {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.w("EvidenceImporter", "ACCESS_FINE_LOCATION not granted; skipping location import.")
+            return null
+        }
+        return suspendCoroutine { continuation ->
         fusedLocationProviderClient.lastLocation
             .addOnSuccessListener { location: Location? ->
                 if (location != null) {
@@ -179,5 +192,6 @@ class EvidenceImporter(
             .addOnFailureListener {
                 continuation.resume(null)
             }
+        }
     }
 }

--- a/app/src/main/java/com/hereliesaz/lexorcist/utils/VideoUtils.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/utils/VideoUtils.kt
@@ -17,24 +17,28 @@ object VideoUtils {
 
     fun extractFrames(context: Context, videoUri: Uri, intervalMs: Int): List<File> {
         val retriever = MediaMetadataRetriever()
-        retriever.setDataSource(context, videoUri)
-
-        val durationStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
-        val durationMs = durationStr?.toLongOrNull() ?: 0
-
         val frames = mutableListOf<File>()
-        var currentTimeMs = 0L
+        try {
+            retriever.setDataSource(context, videoUri)
 
-        while (currentTimeMs < durationMs) {
-            val bitmap = retriever.getFrameAtTime(currentTimeMs * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
-            if (bitmap != null) {
-                val frameFile = saveBitmapToFile(context, bitmap, "frame_${currentTimeMs}.jpg")
-                frames.add(frameFile)
+            val durationStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+            val durationMs = durationStr?.toLongOrNull() ?: 0
+
+            var currentTimeMs = 0L
+            while (currentTimeMs < durationMs) {
+                val bitmap = retriever.getFrameAtTime(currentTimeMs * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+                if (bitmap != null) {
+                    try {
+                        frames.add(saveBitmapToFile(context, bitmap, "frame_${currentTimeMs}.jpg"))
+                    } finally {
+                        bitmap.recycle()
+                    }
+                }
+                currentTimeMs += intervalMs
             }
-            currentTimeMs += intervalMs
+        } finally {
+            retriever.release()
         }
-
-        retriever.release()
         return frames
     }
 
@@ -51,48 +55,56 @@ object VideoUtils {
     }
 
     fun extractAudio(context: Context, videoUri: Uri): String {
-        val extractor = MediaExtractor()
         val parcelFileDescriptor = context.contentResolver.openFileDescriptor(videoUri, "r")
-        extractor.setDataSource(parcelFileDescriptor!!.fileDescriptor)
-
-        val audioTrackIndex = (0 until extractor.trackCount).firstOrNull {
-            val format = extractor.getTrackFormat(it)
-            val mime = format.getString(MediaFormat.KEY_MIME)
-            mime?.startsWith("audio/") == true
-        } ?: throw IOException("No audio track found in video")
-
-        extractor.selectTrack(audioTrackIndex)
-
+            ?: throw IOException("Could not open file descriptor for $videoUri")
+        val extractor = MediaExtractor()
+        var muxer: MediaMuxer? = null
         val outputFile = File.createTempFile("extracted_audio", ".m4a", context.cacheDir)
-        val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
-        val buffer = ByteBuffer.allocate(1024 * 1024)
-        val bufferInfo = MediaCodec.BufferInfo()
-        var isEos = false
+        try {
+            extractor.setDataSource(parcelFileDescriptor.fileDescriptor)
 
-        val trackFormat = extractor.getTrackFormat(audioTrackIndex)
-        val muxerTrackIndex = muxer.addTrack(trackFormat)
-        muxer.start()
+            val audioTrackIndex = (0 until extractor.trackCount).firstOrNull {
+                val format = extractor.getTrackFormat(it)
+                val mime = format.getString(MediaFormat.KEY_MIME)
+                mime?.startsWith("audio/") == true
+            } ?: throw IOException("No audio track found in video")
 
-        while (!isEos) {
-            val sampleSize = extractor.readSampleData(buffer, 0)
-            if (sampleSize < 0) {
-                isEos = true
-            } else {
-                bufferInfo.offset = 0
-                bufferInfo.size = sampleSize
-                bufferInfo.presentationTimeUs = extractor.sampleTime
-                bufferInfo.flags = extractor.sampleFlags
+            extractor.selectTrack(audioTrackIndex)
 
-                muxer.writeSampleData(muxerTrackIndex, buffer, bufferInfo)
-                extractor.advance()
+            muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+            val buffer = ByteBuffer.allocate(1024 * 1024)
+            val bufferInfo = MediaCodec.BufferInfo()
+            var isEos = false
+
+            val trackFormat = extractor.getTrackFormat(audioTrackIndex)
+            val muxerTrackIndex = muxer.addTrack(trackFormat)
+            muxer.start()
+
+            while (!isEos) {
+                val sampleSize = extractor.readSampleData(buffer, 0)
+                if (sampleSize < 0) {
+                    isEos = true
+                } else {
+                    bufferInfo.offset = 0
+                    bufferInfo.size = sampleSize
+                    bufferInfo.presentationTimeUs = extractor.sampleTime
+                    bufferInfo.flags = extractor.sampleFlags
+
+                    muxer.writeSampleData(muxerTrackIndex, buffer, bufferInfo)
+                    extractor.advance()
+                }
             }
+
+            muxer.stop()
+            return outputFile.absolutePath
+        } catch (e: Exception) {
+            // Clean up the partial output file on failure.
+            if (outputFile.exists()) outputFile.delete()
+            throw e
+        } finally {
+            try { muxer?.release() } catch (_: Exception) { /* already released or never started */ }
+            extractor.release()
+            try { parcelFileDescriptor.close() } catch (_: Exception) { /* best-effort */ }
         }
-
-        muxer.stop()
-        muxer.release()
-        extractor.release()
-        parcelFileDescriptor.close()
-
-        return outputFile.absolutePath
     }
 }

--- a/app/src/main/java/com/hereliesaz/lexorcist/viewmodel/CaseViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/lexorcist/viewmodel/CaseViewModel.kt
@@ -408,13 +408,19 @@ constructor(
 
         // Initialize storage location
         viewModelScope.launch {
-            val savedLocation = settingsManager.getStorageLocation()?.first()
-            if (savedLocation?.toString().isNullOrEmpty()) {
+            try {
+                // getStorageLocation() returns a String? path (not a Flow); use it directly.
+                val savedLocation = settingsManager.getStorageLocation()
+                if (savedLocation.isNullOrEmpty()) {
+                    _storageLocation.value = applicationContext.filesDir.absolutePath
+                    Log.i("CaseViewModel", "Storage location initialized to default: ${_storageLocation.value}")
+                } else {
+                    _storageLocation.value = savedLocation
+                    Log.i("CaseViewModel", "Storage location loaded from settings: $savedLocation")
+                }
+            } catch (e: Exception) {
                 _storageLocation.value = applicationContext.filesDir.absolutePath
-                Log.i("CaseViewModel", "Storage location initialized to default: ${_storageLocation.value}")
-            } else {
-                _storageLocation.value = savedLocation.toString()
-                Log.i("CaseViewModel", "Storage location loaded from settings: $savedLocation")
+                Log.e("CaseViewModel", "Failed to initialize storage location; using default", e)
             }
         }
 
@@ -457,13 +463,17 @@ constructor(
 
         // Restore last selected case on app launch
         viewModelScope.launch {
-            val lastSelectedCaseId = sharedPref.getString("last_selected_case_id", null)
-            if (lastSelectedCaseId != null) {
-                val allCases = caseRepository.cases.first()
-                val lastSelectedCase = allCases.find { it.spreadsheetId == lastSelectedCaseId }
-                if (lastSelectedCase != null) {
-                    selectCase(lastSelectedCase)
+            try {
+                val lastSelectedCaseId = sharedPref.getString("last_selected_case_id", null)
+                if (lastSelectedCaseId != null) {
+                    val allCases = caseRepository.cases.first()
+                    val lastSelectedCase = allCases.find { it.spreadsheetId == lastSelectedCaseId }
+                    if (lastSelectedCase != null) {
+                        selectCase(lastSelectedCase)
+                    }
                 }
+            } catch (e: Exception) {
+                Log.e("CaseViewModel", "Failed to restore last selected case", e)
             }
         }
     }
@@ -1515,14 +1525,19 @@ constructor(
                         group.evidence.forEach { evidence ->
                             applicationContext.contentResolver.openInputStream(android.net.Uri.parse(evidence.mediaUri))?.use { inputStream ->
                                 val bitmap = android.graphics.BitmapFactory.decodeStream(inputStream)
-                                val pageInfo = PdfDocument.PageInfo.Builder(bitmap.width, bitmap.height, 1).create()
-                                val page = pdfDocument.startPage(pageInfo)
-                                page.canvas.drawBitmap(bitmap, 0f, 0f, null)
-                                pdfDocument.finishPage(page)
-                                bitmap.recycle()
+                                if (bitmap != null) {
+                                    try {
+                                        val pageInfo = PdfDocument.PageInfo.Builder(bitmap.width, bitmap.height, 1).create()
+                                        val page = pdfDocument.startPage(pageInfo)
+                                        page.canvas.drawBitmap(bitmap, 0f, 0f, null)
+                                        pdfDocument.finishPage(page)
+                                    } finally {
+                                        bitmap.recycle()
+                                    }
+                                }
                             }
                         }
-                        pdfDocument.writeTo(FileOutputStream(pdfFile))
+                        FileOutputStream(pdfFile).use { pdfDocument.writeTo(it) }
                     } catch (e: Exception) {
                         Log.e("MergeSeries", "Error creating PDF", e)
                         // Return null to indicate failure

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 
 [versions]
 androidApplication = "8.13.1"
-aznavrail = "3.10"
+aznavrail = "3.16"
 browser = "1.9.0"
 datastorePreferences = "1.1.7"
 dropboxCoreSdk = "7.0.0"
@@ -171,7 +171,7 @@ androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name =
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose" }
-coil-compose = { group = "io.coil-kt", name = "coil-compose" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version = "2.7.0" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose" }
 itext7-core = { group = "com.itextpdf", name = "itext7-core", version.ref = "itext7Core" }
 apache-poi = { group = "org.apache.poi", name = "poi", version.ref = "poi" }

--- a/index.html
+++ b/index.html
@@ -96,8 +96,12 @@
     </section>
 </div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"
+        integrity="sha512-16esztaSRplJROstbIIdwX3N97V1+pZvV33ABoG1H2OyTttBxEGkTsoIVsiP1iaTtM8b3+hu2kB6pQ4Clr5yug=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"
+        integrity="sha512-Ic9xkERjyZ1xgJ5svx3y0u3xrvfT/uPkV99LBwe68xjy/mGtO+4eURHZBW2xW4SZbFrF1Tf090XqB+EVgXnVjw=="
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="web/script.js"></script>
 </body>
 </html>

--- a/scripts/scrub-leaked-key-history.sh
+++ b/scripts/scrub-leaked-key-history.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# scrub-leaked-key-history.sh
+#
+# PURPOSE
+#   Permanently remove app/google-services.json (which contains the leaked
+#   Google API key AIzaSyCbh_mUGE5srd8ubdhClcsOCdG_JDbkKbo) from the ENTIRE
+#   git history of this repository.
+#
+# ⚠️  THIS REWRITES HISTORY AND IS DESTRUCTIVE.
+#   - It changes every commit SHA after the first commit that touched the file.
+#   - Everyone with a clone must re-clone (or hard-reset) afterwards.
+#   - You must force-push, which can break open PRs.
+#   - DO NOT run this on your only copy. Make a backup first.
+#
+# IMPORTANT: Removing the key from history does NOT un-leak it. The key has
+# been public since Aug 2025 and must be assumed compromised. BEFORE OR AFTER
+# scrubbing, you MUST restrict and/or rotate it (see KEY-REMEDIATION steps at
+# the bottom of this file). Scrubbing only stops the secret scanner from
+# re-flagging it and prevents future clones from seeing it.
+#
+# This script does NOTHING unless you pass --run. By default it prints the plan.
+
+set -euo pipefail
+
+FILE_TO_PURGE="app/google-services.json"
+
+cat <<'BANNER'
+=========================================================================
+ Leaked-key history scrub  (DRY RUN unless --run is passed)
+=========================================================================
+BANNER
+
+DO_RUN="no"
+if [[ "${1:-}" == "--run" ]]; then
+  DO_RUN="yes"
+fi
+
+# --- Preferred tool: git filter-repo --------------------------------------
+# Install: pipx install git-filter-repo   (or)   pip install git-filter-repo
+if command -v git-filter-repo >/dev/null 2>&1 || git filter-repo --help >/dev/null 2>&1; then
+  echo "Tool: git filter-repo (recommended)"
+  echo "Plan:"
+  echo "  1. Work on a FRESH mirror clone (filter-repo refuses a dirty/working repo)."
+  echo "  2. git filter-repo --path ${FILE_TO_PURGE} --invert-paths --force"
+  echo "  3. Re-add the remote, force-push all branches and tags."
+  if [[ "$DO_RUN" == "yes" ]]; then
+    echo
+    echo ">>> Running filter-repo on the CURRENT repo..."
+    echo ">>> (Recommended instead: clone --mirror, run there, then push.)"
+    read -r -p "Type 'SCRUB' to proceed: " confirm
+    [[ "$confirm" == "SCRUB" ]] || { echo "Aborted."; exit 1; }
+    git filter-repo --path "${FILE_TO_PURGE}" --invert-paths --force
+    echo "Done. Now: git remote add origin <url> && git push --force --all && git push --force --tags"
+  fi
+  exit 0
+fi
+
+# --- Fallback tool: BFG Repo-Cleaner ---------------------------------------
+# Download bfg.jar from https://rtyley.github.io/bfg-repo-cleaner/  (needs Java)
+cat <<EOF
+Tool: git filter-repo NOT found. Fallback = BFG Repo-Cleaner.
+Plan (run against a fresh 'git clone --mirror'):
+  1. git clone --mirror <repo-url> repo-mirror.git
+  2. cd repo-mirror.git
+  3. java -jar bfg.jar --delete-files google-services.json
+  4. git reflog expire --expire=now --all && git gc --prune=now --aggressive
+  5. git push --force
+EOF
+
+# ---------------------------------------------------------------------------
+# KEY-REMEDIATION (do this regardless of history scrubbing) -- console only:
+#
+# 1. Google Cloud Console -> APIs & Services -> Credentials -> the leaked key.
+# 2. Application restrictions: "Android apps" -> add package
+#    com.hereliesaz.lexorcist + the release/debug signing SHA-1 fingerprints.
+# 3. API restrictions: "Restrict key" -> allow ONLY the APIs the app uses
+#    (e.g. Drive, Sheets, Apps Script, Generative Language) -- nothing else.
+# 4. Strongly recommended: create a NEW key, swap it into a fresh
+#    google-services.json (kept out of git -- it is already in .gitignore),
+#    then delete the old leaked key.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
Makes the app build and pushes it toward production-robust. The project did **not compile** before this branch (a refactor that removed whisper.cpp/NDK was never built); now `compileDebugKotlin`, `assembleDebug`, and `testDebugUnitTest` (**25/25 pass**) all succeed.

## What changed (by area)

**Build (was broken)**
- Fix unresolved `casesResult` reference in `LocalFileStorageService`.
- Pin missing `coil-compose` (2.7.0); bump `aznavrail` 3.10→3.16 (3.10 publishes no artifact on JitPack).

**Crashes & data integrity**
- `CaseViewModel`: `getStorageLocation()` returns `String?`, not a Flow — drop the erroneous `.first()` (read the first char / could throw `NoSuchElementException`); guard init coroutines.
- `EvidenceRepositoryImpl`: log previously-swallowed refresh/update/delete errors.
- Guard `toUri().path!!` NPE sites (`SyncManager`, `LocalFileStorageService`).

**Media pipeline (leaks / OOM / dead feature)**
- `VideoProcessingService`: actually OCR each frame (was hardcoded `""`); recycle frames; release retriever in `finally`.
- `OcrProcessingService`: downsample bitmaps (`inSampleSize`) to avoid OOM on large scans; recycle after OCR; add reusable `recognizeTextFromBitmap`.
- `VideoUtils.extractAudio`: remove `!!` crash; try/finally cleanup of extractor/muxer/PFD; delete partial output on failure. `extractFrames` recycles bitmaps.
- `PackagingService`: delete partial archive on failure. PDF merge: recycle bitmaps in `finally`, close stream.

**Permissions**
- Add `READ_MEDIA_IMAGES/VIDEO/AUDIO` (API 33+); cap legacy `READ_EXTERNAL_STORAGE` at `maxSdk 32`.
- Runtime `ACCESS_FINE_LOCATION` check in `EvidenceImporter`.

**Google Drive sync**
- Wire the real `GoogleDriveCloudStorageProvider` into DI (was a disabled stub returning errors).
- Log sync results in `AppLifecycleObserver`. OneDrive/Dropbox UI gated off behind `showExperimentalCloudProviders` until those features are implemented.

**Hardening**
- ProGuard keep rules for reflection-heavy libs (Rhino, POI, iText, gRPC, MSAL, Vosk, Dropbox, TFLite).
- Network connect/read timeouts on `GoogleApiService`.
- `ScriptRunner` runs off the main thread (ANR fix; it uses `runBlocking` for network bridges).
- `GlobalLoadingState` count+flag made atomic; `CaseRepositoryImpl` stale-allegations race fixed.

**Security alerts** (from repo scanning)
- CodeQL workflow-permissions → added least-privilege `permissions:` (and fixed the workflow's JDK 11→17, which would have failed under AGP 8.13).
- CodeQL untrusted-source → SRI on the GSAP CDN scripts in `index.html`.
- Dependabot → pinned vulnerable transitive libs present in the graph (commons-lang3, commons-compress, jackson). Several Netty/jose4j/BouncyCastle alerts appear stale (not in the current graph).

## ⚠️ Requires maintainer action
- **Rotate/restrict the leaked Google API key** (`AIzaSyCbh...`) — it's in git **history** and must be assumed compromised. `scripts/scrub-leaked-key-history.sh` (prepared, not run) has history-scrub + Google Cloud Console restriction/rotation steps.
- **Before shipping**: run `assembleRelease` with the signing keystore to confirm the new ProGuard rules hold under R8, and do the manual device smoke-test (sign-in → image/video OCR → Drive sync → rotation/process-death).

## Notes
- `protobuf-javalite` (3.19.1, transitive from MediaPipe) intentionally **not** force-upgraded — risks breaking on-device ML and the DoS isn't reachable here.
- OneDrive/Dropbox code is kept intact (UI-gated) for future implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)