### PR TITLE
Add google-services.json.template for CI secret injection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
         env:
           GOOGLE_SERVICES_API_KEY: ${{ secrets.GOOGLE_SERVICES_API_KEY }}
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          PROJECT_NUMBER: ${{ secrets.PROJECT_NUMBER }}
+          MOBILESDK_APP_ID: ${{ secrets.MOBILESDK_APP_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           ARCORE_API_KEY: ${{ secrets.ARCORE_API_KEY }}
         run: |

--- a/app/google-services.json.template
+++ b/app/google-services.json.template
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "{{PROJECT_NUMBER}}",
+    "project_id": "{{PROJECT_ID}}",
+    "storage_bucket": "{{PROJECT_ID}}.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "{{MOBILESDK_APP_ID}}",
+        "android_client_info": {
+          "package_name": "com.hereliesaz.lexorcist"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "{{CLIENT_ID}}",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "{{GOOGLE_SERVICES_API_KEY}}"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "{{CLIENT_ID}}",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## Summary
- The `Inject Google Services` step in `.github/workflows/build.yml` generates `app/google-services.json` from `app/google-services.json.template` — but that template did not exist in the repo, so the file was never produced and `:app:processDebugGoogleServices` failed with `google-services.json is missing`.
- Adds `app/google-services.json.template` with placeholder fields (rendered via the existing `sed → envsubst` pipeline) and a fixed package name (`com.hereliesaz.lexorcist`).
- Wires two new env vars into the inject step so the missing fields can be supplied as repository secrets.

## Required repository secrets
This needs two **new** secrets added to the repo (Settings → Secrets and variables → Actions). Neither is sensitive — both ship inside every distributed APK:
- `PROJECT_NUMBER` — the Firebase project number (~12 digits)
- `MOBILESDK_APP_ID` — the Android app ID, format `1:<project_number>:android:<hash>`

Existing secrets already used by the template: `PROJECT_ID`, `GOOGLE_SERVICES_API_KEY`, `CLIENT_ID`.

Note: `storage_bucket` is derived as `<PROJECT_ID>.firebasestorage.app`. If the project's bucket uses the legacy `.appspot.com` suffix, update the template accordingly.

## Context
Follow-up to #100 (overload-ambiguity + SDK-license fixes, already merged). This is the third and final pre-existing CI blocker uncovered while getting the build green.

## Test plan
- [ ] Add the `PROJECT_NUMBER` and `MOBILESDK_APP_ID` repository secrets.
- [ ] CI `build-and-release` generates a valid `app/google-services.json` and `:app:processDebugGoogleServices` succeeds.
- [ ] `./gradlew assembleDebug` completes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvAPamfA3nJDQqnk8fjT61)_

## Summary by Sourcery

Add missing Google Services template and wire required secrets into the CI build workflow so google-services.json can be generated during builds.

Build:
- Pass PROJECT_NUMBER and MOBILESDK_APP_ID secrets into the Inject Google Services step in the CI build workflow.

Chores:
- Add app/google-services.json.template to serve as the source for generating google-services.json in CI.