### PR TITLE
Use APP_ID secret for google-services injection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           GOOGLE_SERVICES_API_KEY: ${{ secrets.GOOGLE_SERVICES_API_KEY }}
           PROJECT_ID: ${{ secrets.PROJECT_ID }}
           PROJECT_NUMBER: ${{ secrets.PROJECT_NUMBER }}
-          MOBILESDK_APP_ID: ${{ secrets.MOBILESDK_APP_ID }}
+          APP_ID: ${{ secrets.APP_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           ARCORE_API_KEY: ${{ secrets.ARCORE_API_KEY }}
         run: |

--- a/app/google-services.json.template
+++ b/app/google-services.json.template
@@ -7,7 +7,7 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "{{MOBILESDK_APP_ID}}",
+        "mobilesdk_app_id": "{{APP_ID}}",
         "android_client_info": {
           "package_name": "com.hereliesaz.lexorcist"
         }


### PR DESCRIPTION
## Summary
- The build workflow's "Inject Google Services" step read `secrets.MOBILESDK_APP_ID` to fill the `{{MOBILESDK_APP_ID}}` placeholder in `app/google-services.json.template`. The repository secret is named `APP_ID`, so the placeholder was never substituted and `mobilesdk_app_id` came out empty.
- Aligned both files to use `APP_ID`:
  - `.github/workflows/build.yml:35` — `secrets.MOBILESDK_APP_ID` → `secrets.APP_ID`
  - `app/google-services.json.template:10` — `{{MOBILESDK_APP_ID}}` → `{{APP_ID}}`

## Test plan
- [ ] Push triggers `Merged Build & Release`; confirm the "Inject Google Services" step produces a `google-services.json` with a populated `mobilesdk_app_id`.
- [ ] Build completes and produces a signed APK.

https://claude.ai/code/session_01JvAPamfA3nJDQqnk8fjT61

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvAPamfA3nJDQqnk8fjT61)_