### PR TITLE
Fix duplicate class build failure (litert vs litert-api)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -139,6 +139,13 @@ android {
     ndkVersion = "29.0.14033849 rc4"
 }
 
+// The litert runtime AAR bundles the org.tensorflow.lite API classes that also ship
+// in the standalone litert-api module (pulled in transitively), which collide at
+// checkDuplicateClasses. Drop the redundant standalone module.
+configurations.all {
+    exclude(group = "com.google.ai.edge.litert", module = "litert-api")
+}
+
 dependencies {
 
     constraints {


### PR DESCRIPTION
## Summary
- `:app:checkDebugDuplicateClasses` was failing: `org.tensorflow.lite.*` classes (DataType, InterpreterApi, Tensor, TensorFlowLite, ...) appeared in **both** `com.google.ai.edge.litert:litert:2.1.5` (the runtime AAR bundles the API classes) and `com.google.ai.edge.litert:litert-api:1.0.1` (pulled in transitively).
- Added a `configurations.all { exclude(group = "com.google.ai.edge.litert", module = "litert-api") }` so only the runtime-bundled copy remains. The runtime AAR already contains these classes (the failure log confirms it), so nothing is lost at compile or runtime.

## Notes
- Couldn't reproduce the Android build locally (needs the SDK + the `google-services.json` secrets only present in CI), so this relies on dependency analysis. CI on this PR is the real verification.

## Test plan
- [ ] `build-and-release` reaches/clears `:app:checkDebugDuplicateClasses` and the APK builds.

https://claude.ai/code/session_01JvAPamfA3nJDQqnk8fjT61

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvAPamfA3nJDQqnk8fjT61)_